### PR TITLE
local generated repository is missing the required plugins to be used as a p2 repo from eclipse

### DIFF
--- a/jsonedit-feature/feature.xml
+++ b/jsonedit-feature/feature.xml
@@ -90,4 +90,26 @@ All Recipient&apos;s rights under this Agreement shall terminate if it fails
          version="0.9.5"
          unpack="false"/>
 
+   <plugin
+         id="jsonedit-model"
+         download-size="0"
+         install-size="0"
+         version="0.9.5"
+         unpack="false"/>
+
+
+   <plugin
+         id="jsonedit-outline"
+         download-size="0"
+         install-size="0"
+         version="0.9.5"
+         unpack="false"/>
+
+   <plugin
+         id="jsonedit-reader"
+         download-size="0"
+         install-size="0"
+         version="0.9.5"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
The jsonedit-feature only includes the core plugin, and not the deps. Hence they are not added to the repo and eclipse will fail to install the editor on required deps.

This adds them in.

Not sure if this was intended, and you have some other strategy for the deps... 
